### PR TITLE
Update Composer installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Peridot core and some commonly used packages to let you start doing BDD in PHP A
 We recommend installing the jumpstart via composer:
 
 ```
-$ composer require --dev peridot-php/peridot-jumpstart:~1.0
+$ composer require --dev peridot-php/peridot-jumpstart
 ```
 
 ##Getting started


### PR DESCRIPTION
Composer automatically picks the latest stable (or dev, if minimum stability is set to dev) version when doing `composer require`

Doing it this way also prevents you from needing to update the README file every time you release a new version
